### PR TITLE
Move isNumber helper inside of isWithin body

### DIFF
--- a/lib/isWithin.js
+++ b/lib/isWithin.js
@@ -1,7 +1,5 @@
 import R from 'ramda'
 
-const isNumber = R.is(Number)
-
 /**
  * Given a min and max, determines if the value is included
  * in the range.
@@ -21,5 +19,6 @@ const isNumber = R.is(Number)
  * RS.isWithin(1, 5, 5.1) //=> false
  */
 export default R.curry((min, max, value) => {
+  const isNumber = R.is(Number)
   return isNumber(min) && isNumber(max) && isNumber(value) && R.gte(value, min) && R.gte(max, value)
 })


### PR DESCRIPTION
This may look like a very subtle change but in fact it resolves some issues while running a bundle built with Webpack. As Webpack builds inject polyfills during runtime, in might also affect some base types, like **Number**. In this particular situation, **isNumber** helper always returned false on some older platforms (like iOS 8 or Android 4.4-ish) because its prototype chain had been changed during runtime. In other words, it tried to compare the old constructor of a type with the new one after applying the polyfills.

I found this bug while working with https://github.com/skellock/apisauce in an app of mine. I was always getting "UNKNOWN_ERROR" while sending any request, because of the issue I described above (As far as I remember, **in200s** function from apisauce also returns false, too) 


See: 
http://stackoverflow.com/questions/19683444/why-does-changing-the-prototype-of-a-function-affect-instanceof-for-objects-a
https://github.com/ramda/ramda/blob/master/src/is.js